### PR TITLE
only specify ?: for optional parameters

### DIFF
--- a/src/generate-typescript-annotations.js
+++ b/src/generate-typescript-annotations.js
@@ -162,7 +162,7 @@ function formatTypedParams(params, typedParams, formatType) {
         return `${name}?: ${formatType(noUndefined)}`;
       }
 
-      return `${name}?: ${formatType(types)}`;
+      return `${name}: ${formatType(types)}`;
     })
     .join(', ');
 }


### PR DESCRIPTION
i'm pretty sure we can enforce this since FES throws errors at runtime if you pass undefined/null when non-optional.