### PR TITLE
fixed emitter.ts fs.close

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -84,7 +84,11 @@ export class Emitter {
           if (err) {
             throw err;
           } else {
-            fs.close(fd);
+            fs.close(fd, err => {
+              if (err) {
+                  throw err;
+              }
+            });
           }
         });
       }


### PR DESCRIPTION
TypeError [ERR_INVALID_CALLBACK]: Callback must be a function. Received undefined
    at makeCallback (fs.js:168:11)
    at Object.close (fs.js:427:14)